### PR TITLE
PCI and LibVector

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libvector"]
+	path = libvector
+	url = https://github.com/NDRAEY/libvector

--- a/config.sh
+++ b/config.sh
@@ -1,5 +1,5 @@
 SYSTEM_HEADER_PROJECTS="libc kernel"
-PROJECTS="libc kernel"
+PROJECTS="libc libvector kernel"
 
 export MAKE=${MAKE:-make}
 export HOST=${HOST:-$(./default-host.sh)}

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+git submodule init
+git submodule update --remote
+
+for i in patches/*; do
+    patch -p1 < patches/libvector-install-rule.patch
+done

--- a/kernel/arch/i386/drv/pci.c
+++ b/kernel/arch/i386/drv/pci.c
@@ -1,0 +1,152 @@
+#include <stdint.h>
+#include <kernel/sys/ports.h>
+#include <stdlib.h>
+#include <kernel/drv/serial_port.h>
+
+#define PCI_ADDRESS_PORT 0xCF8      /// Точка входа || Адрес конфигурации, который требуется для доступа
+#define PCI_DATA_PORT 0xCFC         /// Пароль входа || Генерирует доступ к конфигурации и будет передавать данные в или из регистра
+
+typedef struct {
+    uint16_t vendor_id;
+    uint16_t device_id;
+    uint16_t klass;
+    uint16_t subclass;
+    uint16_t bus;
+    uint16_t slot;
+    uint16_t func;
+    uint16_t hdrtype;
+} pci_device_t;
+
+uint16_t pci_read_confspc_word(uint8_t bus, uint8_t slot, uint8_t function, uint8_t offset) {
+    uint32_t addr;
+    // uint32_t bus32 = bus;
+    uint32_t slot32 = slot;
+    uint32_t func32 = function;
+    
+    addr = (uint32_t)(((uint32_t)bus << 16) | (slot32 << 11) |
+           (func32 << 8) | (offset & 0xfc) | ((uint32_t)0x80000000)); //yes, this line is copied from osdev
+
+    outl(PCI_ADDRESS_PORT, addr);
+
+    return inl(PCI_DATA_PORT) >> ((offset & 2) * 8);
+}
+
+__attribute__((always_inline))
+inline uint8_t pci_get_class(uint8_t bus, uint8_t slot, uint8_t function) {
+    /* Сдвигаем, чтобы оставить только нужные данные в переменной */
+    return (uint8_t) (pci_read_confspc_word(bus, slot, function, 10) >> 8);
+}
+
+/**
+ * @brief [PCI] Получение под-категории устройства
+ *
+ * @param bus  Шина
+ * @param slot  Слот
+ * @param function  Функция
+ * @return uint8_t Подкатегория устройства
+ */
+__attribute__((always_inline))
+inline uint8_t pci_get_subclass(uint8_t bus, uint8_t slot, uint8_t function) {
+    /* Сдвигаем, чтобы оставить только нужные данные в переменной */
+    return (uint8_t) pci_read_confspc_word(bus, slot, function, 10);
+}
+
+/**
+ * @brief [PCI] Получение HDR-тип устройства
+ *
+ * @param bus  Шина
+ * @param slot  Слот
+ * @param function  Функция
+ * @return uint8_t HDR-тип
+ */
+__attribute__((always_inline))
+inline uint8_t pci_get_hdr_type(uint8_t bus, uint8_t slot, uint8_t function) {
+    /* Сдвигаем, чтобы оставить только нужные данные в переменной */
+    return (uint8_t) pci_read_confspc_word(bus, slot, function, 7);
+}
+
+/**
+ * @brief [PCI] Получение ID-поставщика
+ *
+ * @param bus  Шина
+ * @param slot  Слот
+ * @param function  Функция
+ * @return ID-поставщика
+ */
+__attribute__((always_inline))
+inline uint16_t pci_get_vendor(uint8_t bus, uint8_t slot, uint8_t function) {
+    /* Сдвигаем, чтобы оставить только нужные данные в переменной */
+    return pci_read_confspc_word(bus, slot, function, 0);
+}
+
+/**
+ * @brief [PCI] Получение ID-Устройства
+ *
+ * @param bus  Шина
+ * @param slot  Слот
+ * @param function  Функция
+ * @return ID-Устройства
+ */
+__attribute__((always_inline))
+inline uint16_t pci_get_device(uint8_t bus, uint8_t slot, uint8_t function) {
+    /* Сдвигаем, чтобы оставить только нужные данные в переменной */
+    return pci_read_confspc_word(bus, slot, function, 2);
+}
+
+void pci_scan_everything() {
+    for (uint32_t bus = 0; bus < 256; bus++) {
+        for (uint8_t slot = 0; slot < 32; slot++) {
+            uint32_t func = 0;
+            uint16_t hdrtype = 0, clid = 0, sclid = 0, device = 0;
+
+            uint16_t vendor = pci_get_vendor(bus, slot, func);
+
+            if (vendor != 0xFFFF) {
+                clid = pci_get_class(bus, slot, func);
+                sclid = pci_get_subclass(bus, slot, func);
+                hdrtype = pci_get_hdr_type(bus, slot, func);
+                device = pci_get_device(bus, slot, func);
+
+                pci_device_t* dev = calloc(1, sizeof(pci_device_t));
+                dev->klass = clid;
+                dev->subclass = sclid;
+                dev->bus = bus;
+                dev->slot = slot;
+                dev->func = func;
+                dev->hdrtype = hdrtype | 0x80;
+                dev->vendor_id = vendor;
+                dev->device_id = device;
+
+                qemu_log("%d.%d [%d:%d:%d] %x:%x", dev->klass, dev->subclass, dev->bus, dev->slot, dev->func, dev->vendor_id, dev->device_id);
+
+                free(dev);
+            }
+
+            if ((hdrtype & 0x80) == 0) {
+                for (func = 1; func < 8; func++) {
+                    vendor = pci_get_vendor(bus, slot, func);
+
+                    if (vendor != 0xFFFF) {
+                        clid = pci_get_class(bus, slot, func);
+                        sclid = pci_get_subclass(bus, slot, func);
+                        device = pci_get_device(bus, slot, func);
+
+                        pci_device_t* dev = calloc(1, sizeof(pci_device_t));
+                        dev->klass = clid;
+                        dev->subclass = sclid;
+                        dev->bus = bus;
+                        dev->slot = slot;
+                        dev->hdrtype = hdrtype;
+                        dev->func = func;
+                        dev->vendor_id = vendor;
+                        dev->device_id = device;
+
+                        qemu_log("%d.%d [%d:%d:%d] %x:%x", dev->klass, dev->subclass, dev->bus, dev->slot, dev->func, dev->vendor_id, dev->device_id);
+                        
+                        free(dev);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/kernel/arch/i386/hal.c
+++ b/kernel/arch/i386/hal.c
@@ -39,6 +39,10 @@ int init_hal(__attribute__((unused)) multiboot_info_t* multiboot_info) {
     beep(6, 100);
     check();
     printf("PC Speaker testing!\n");
+
+    void pci_scan_everything();
+    pci_scan_everything();
+
     memdisk_init(1 << 17);
     ata_init();
     printf("\n");

--- a/kernel/arch/i386/make.config
+++ b/kernel/arch/i386/make.config
@@ -37,4 +37,5 @@ $(ARCHDIR)/mini_programs/disks.o \
 $(ARCHDIR)/mini_programs/dhv.o \
 $(ARCHDIR)/mini_programs/meminfo.o \
 $(ARCHDIR)/panic.o \
+$(ARCHDIR)/drv/pci.o \
 $(ARCHDIR)/hal.o 

--- a/kernel/include/kernel/sys/kheap.h
+++ b/kernel/include/kernel/sys/kheap.h
@@ -4,6 +4,17 @@
 #include <stddef.h>
 #include "../multiboot.h"
 
+typedef struct header {
+    size_t size;
+    unsigned int magic;
+    struct header* next;
+} header_t;
+
+typedef struct {
+    size_t size;
+    unsigned int magic;
+} footer_t;
+
 void kheap_init(void* start, size_t size);
 void* kmalloc(size_t size);
 void kfree(void* ptr);

--- a/kernel/kernel/kernel.c
+++ b/kernel/kernel/kernel.c
@@ -1,9 +1,9 @@
-#include "kernel/drv/speaker.h"
 #include "kernel/sys/console.h"
 #include <kernel/vfs.h>
 #include <kernel/fs/fat32/fat32.h>
 #include <kernel/fs/fat32/fat32_to_vfs.h>
 #include <kernel/kernel.h>
+#include <math.h>
 
 multiboot_info_t* multiboot = 0;
 

--- a/kernel/kernel/kheap.c
+++ b/kernel/kernel/kheap.c
@@ -7,17 +7,6 @@
 #define HEAP_MIN_SIZE 0x400000
 #define HEAP_SIZE_PERCENTAGE 75
 
-typedef struct header {
-    size_t size;
-    unsigned int magic;
-    struct header* next;
-} header_t;
-
-typedef struct {
-    size_t size;
-    unsigned int magic;
-} footer_t;
-
 static void* heap_start;
 size_t heap_size;
 static header_t* free_list;

--- a/libc/include/stdlib.h
+++ b/libc/include/stdlib.h
@@ -27,7 +27,7 @@ void dtoa(double num, char* buffer, size_t precision);
 void gtoa(double value, char *buffer, int precision);
 void etoa(double value, char* buffer, int precision);
 void* malloc(size_t size);
-void* realloc(void* ptr, size_t old_size, size_t new_size);
+void* realloc(void* ptr, size_t new_size);
 void utoa(unsigned int value, char *buffer, int base);
 void* calloc(size_t num, size_t size);
 unsigned long long strtoull(const char* str, char** endptr, int base);

--- a/libc/stdlib/realloc.c
+++ b/libc/stdlib/realloc.c
@@ -1,7 +1,11 @@
 #include <kernel/kernel.h>
+#include <kernel/sys/kheap.h>
 
 // Функция my_realloc
-void* realloc(void* ptr, size_t old_size, size_t new_size) {
+void* realloc(void* ptr, size_t new_size) {
+    header_t* header = (header_t*)((char*)ptr - sizeof(header_t));
+    size_t old_size = header->size;
+
     // Если новый размер равен 0, то поведение функции должно быть аналогично free
     if (new_size == 0) {
         free(ptr);

--- a/patches/libvector-install-rule.patch
+++ b/patches/libvector-install-rule.patch
@@ -1,0 +1,16 @@
+diff '--color=auto' -crB /home/ndraey/libvector/Makefile libvector/Makefile
+*** ../libvector/Makefile	Wed Sep  4 13:08:44 2024
+--- libvector/Makefile	Wed Sep  4 13:14:41 2024
+***************
+*** 12,17 ****
+--- 12,21 ----
+  $(OBJS): %.o: %.c
+  	$(CC) $(CFLAGS) $< -c -o $@
+  
++ install: $(OUT)
++ 	mkdir -p $(DESTDIR)$(LIBDIR)
++ 	cp $(OUT) $(DESTDIR)$(LIBDIR)
++ 	
+  clean:
+  	-rm $(OBJS)
+  	-rm $(OUT)


### PR DESCRIPTION
Do not remove LibVector from production, it will be used for PCI devices caching, making search faster